### PR TITLE
Menthor domain was sold, use the WayBackMachine

### DIFF
--- a/classes/aspects/mode/examples.rst
+++ b/classes/aspects/mode/examples.rst
@@ -2,14 +2,14 @@ Examples
 --------
 
 .. _mode-examples-ex1:
-**EX1:** Fragment from the Configuration Management Task Ontology (`see more <http://www.menthor.net/cmto.html>`__):
+**EX1:** Fragment from the Configuration Management Task Ontology (`see more <http://web.archive.org/web/20171008151908/http://www.menthor.net/cmto.html>`__):
 
 .. container:: figure
 
    |Example CMT|
 
 .. _mode-examples-ex2:
-**EX2:** Fragment from the OntoUML Org Ontology (O3) (`see more <http://www.menthor.net/o3.html>`__):
+**EX2:** Fragment from the OntoUML Org Ontology (O3) (`see more <http://web.archive.org/web/20171008152055/http://www.menthor.net/o3.html>`__):
 
 .. container:: figure
 

--- a/classes/nonsortals/category/examples.rst
+++ b/classes/nonsortals/category/examples.rst
@@ -2,14 +2,14 @@ Examples
 --------
 
 .. _category-examples-ex1:
-**EX1:** Fragment from the ECG Ontology (`see more <http://www.menthor.net/ecg.html>`__):
+**EX1:** Fragment from the ECG Ontology (`see more <http://web.archive.org/web/20171008151934/http://www.menthor.net/ecg.html>`__):
 
 .. container:: figure
 
    |Example ECG|
 
 .. _category-examples-ex2:
-**EX2:** Fragment from UFO-S, a commitment-based service ontology (`see more <http://www.menthor.net/ufo-s.html>`__):
+**EX2:** Fragment from UFO-S, a commitment-based service ontology (`see more <http://web.archive.org/web/20171007071851/http://www.menthor.net/ufo-s.html>`__):
 
 .. container:: figure
 

--- a/classes/nonsortals/mixin/examples.rst
+++ b/classes/nonsortals/mixin/examples.rst
@@ -2,14 +2,14 @@ Examples
 --------
 
 .. _mixin-examples-ex1:
-**EX1:** Conceptual model based on the Music Ontology (`see more <http://www.menthor.net/music-ontology.html>`__):
+**EX1:** Conceptual model based on the Music Ontology (`see more <http://web.archive.org/web/20171008152050/http://www.menthor.net/music-ontology.html>`__):
 
 .. container:: figure
 
    |Example Music|
 
 .. _mixin-examples-ex2:
-**EX2:** Fragments extracted from the OntoUML Org Ontology (O3), a model about the active structure of organisations (`see more <http://www.menthor.net/o3.html>`__):
+**EX2:** Fragments extracted from the OntoUML Org Ontology (O3), a model about the active structure of organisations (`see more <http://web.archive.org/web/20171008152055/http://www.menthor.net/o3.html>`__):
 
 .. container:: figure
 

--- a/classes/nonsortals/rolemixin/examples.rst
+++ b/classes/nonsortals/rolemixin/examples.rst
@@ -2,14 +2,14 @@ Examples
 --------
 
 .. _rolemixin-examples-ex1:
-**EX1:** Fragment of the OntoUML Org Ontology (O3) (`see more <http://www.menthor.net/o3.html>`__):
+**EX1:** Fragment of the OntoUML Org Ontology (O3) (`see more <http://web.archive.org/web/20171008152055/http://www.menthor.net/o3.html>`__):
 
 .. container:: figure
 
    |Example O3|
 
 .. _rolemixin-examples-ex2:
-**EX2:** Fragment of a conceptual model about Brazilian Public Tenders (`see more <http://www.menthor.net/public-tenders.html>`__):
+**EX2:** Fragment of a conceptual model about Brazilian Public Tenders (`see more <http://web.archive.org/web/20171008152151/http://www.menthor.net/public-tenders.html>`__):
 
 .. container:: figure
 

--- a/classes/sortals/collective/examples.rst
+++ b/classes/sortals/collective/examples.rst
@@ -2,14 +2,14 @@ Examples
 --------
 
 .. _collective-examples-ex1:
-**EX1:** Fragment from the a conceptual model about the human genome (`see more <http://www.menthor.net/cshg.html>`__):
+**EX1:** Fragment from the a conceptual model about the human genome (`see more <http://web.archive.org/web/20171008151924/http://www.menthor.net/cshg.html>`__):
 
 .. container:: figure
 
    |Example Human Genome|
 
 .. _collective-examples-ex2:
-**EX2:** Fragment from the Normative Acts Ontology (`see more <http://www.menthor.net/normative-acts.html>`__):
+**EX2:** Fragment from the Normative Acts Ontology (`see more <http://web.archive.org/web/20171007171607/http://www.menthor.net/normative-acts.html>`__):
 
 .. container:: figure
 

--- a/classes/sortals/kind/examples.rst
+++ b/classes/sortals/kind/examples.rst
@@ -2,14 +2,14 @@ Examples
 --------
 
 .. _kind-examples-ex1:
-**EX1:** Fragment from the Configuration Management Task Ontology (`see more <http://www.menthor.net/cmto.html>`__):
+**EX1:** Fragment from the Configuration Management Task Ontology (`see more <http://web.archive.org/web/20171008151908/http://www.menthor.net/cmto.html>`__):
 
 .. container:: figure
 
    |Example MTO|
 
 .. _kind-examples-ex2:
-**EX2:** Fragment from the OntoUML Org Ontology (O3) (`see more <http://www.menthor.net/o3.html>`__):
+**EX2:** Fragment from the OntoUML Org Ontology (O3) (`see more <http://web.archive.org/web/20171008152055/http://www.menthor.net/o3.html>`__):
 
 .. container:: figure
 

--- a/classes/sortals/kind/faq.rst
+++ b/classes/sortals/kind/faq.rst
@@ -11,6 +11,6 @@ Common questions
 
    |Example O1|
 
-This example was extracted from the Software Requirements Reference Ontology (SRRO). Click `here <http://www.menthor.net/srro.html>`__ to take a look at it.
+This example was extracted from the Software Requirements Reference Ontology (SRRO). Click `here <http://web.archive.org/web/20171008152212/http://www.menthor.net/srro.html>`__ to take a look at it.
 
 .. |Example O1| image:: _images/ontouml_kind_example_o1.png

--- a/classes/sortals/phase/examples.rst
+++ b/classes/sortals/phase/examples.rst
@@ -2,7 +2,7 @@ Examples
 --------
 
 .. _phase-examples-ex1:
-**EX1:** Conceptual model about Brazilian Universities (`see more <http://www.menthor.net/university.html>`__):
+**EX1:** Conceptual model about Brazilian Universities (`see more <http://web.archive.org/web/20171007171848/http://www.menthor.net/university.html>`__):
 
 .. container:: figure
 

--- a/classes/sortals/relator/examples.rst
+++ b/classes/sortals/relator/examples.rst
@@ -2,28 +2,28 @@ Examples
 --------
 
 .. _relator-examples-ex1:
-**EX1:** Conceptual model about the Catholic Clergy (`see more <http://www.menthor.net/clergy.html>`__):
+**EX1:** Conceptual model about the Catholic Clergy (`see more <http://web.archive.org/web/20171008151858/http://www.menthor.net/clergy.html>`__):
 
 .. container:: figure
 
    |Example Catholic Clergy|
 
 .. _relator-examples-ex2:
-**EX2:** Fragment of a conceptual model representing the worldview of a possible parking lot management system (`see more <http://www.menthor.net/parking-lot.html>`__):
+**EX2:** Fragment of a conceptual model representing the worldview of a possible parking lot management system (`see more <http://web.archive.org/web/20171008152130/http://www.menthor.net/parking-lot.html>`__):
 
 .. container:: figure
 
    |Example Parking Lot|
 
 .. _relator-examples-ex3:
-**EX3:** UFO-S fragment focused on service offering (`see more <http://www.menthor.net/ufo-s.html>`__):
+**EX3:** UFO-S fragment focused on service offering (`see more <http://web.archive.org/web/20171007071851/http://www.menthor.net/ufo-s.html>`__):
 
 .. container:: figure
 
    |Example UFO-S|
 
 .. _relator-examples-ex4:
-**EX4:** Fragment of a conceptual model about the human genome (`see more <http://www.menthor.net/cshg.html>`__):
+**EX4:** Fragment of a conceptual model about the human genome (`see more <http://web.archive.org/web/20171008151924/http://www.menthor.net/cshg.html>`__):
 
 .. container:: figure
 

--- a/classes/sortals/role/examples.rst
+++ b/classes/sortals/role/examples.rst
@@ -3,7 +3,7 @@ Examples
 
 .. _role-examples-ex1:
 **EX1:** Conceptual model about roles in the Catholic clergy (`see
-more <http://www.menthor.net/clergy.html>`__):
+more <http://web.archive.org/web/20171008151858/http://www.menthor.net/clergy.html>`__):
 
 .. container:: figure
 
@@ -11,7 +11,7 @@ more <http://www.menthor.net/clergy.html>`__):
 
 .. _role-examples-ex2:
 **EX2:** Fragment from an ontological analysis of a Human Genome scheme
-(`see more <http://www.menthor.net/normative-acts.html>`__):
+(`see more <http://web.archive.org/web/20171007171607/http://www.menthor.net/normative-acts.html>`__):
 
 .. container:: figure
 
@@ -24,7 +24,7 @@ more <http://www.menthor.net/clergy.html>`__):
 
 .. _role-examples-ex3:
 **EX3:** Fragment of the OntoUML Org Ontology (O3) (`see
-more <http://www.menthor.net/o3.html>`__):
+more <http://web.archive.org/web/20171008152055/http://www.menthor.net/o3.html>`__):
 
 .. container:: figure
 

--- a/classes/sortals/subkind/examples.rst
+++ b/classes/sortals/subkind/examples.rst
@@ -10,7 +10,7 @@ Examples
 
 .. _subkind-examples-ex2:
 **EX2:** Fragment from the Normative Acts Ontology (`see
-more <http://www.menthor.net/normative-acts.html>`__):
+more <http://web.archive.org/web/20171007171607/http://www.menthor.net/normative-acts.html>`__):
 
 .. container:: figure
 
@@ -18,7 +18,7 @@ more <http://www.menthor.net/normative-acts.html>`__):
 
 .. _subkind-examples-ex3:
 **EX3:** Fragment of a conceptual model about Brazilian Universities
-(`see more <http://www.menthor.net/university.html>`__):
+(`see more <http://web.archive.org/web/20171007171848/http://www.menthor.net/university.html>`__):
 
 .. container:: figure
 

--- a/relationships/formal/examples.rst
+++ b/relationships/formal/examples.rst
@@ -2,7 +2,7 @@ Examples
 --------
 
 .. _formal-examples-ex1:
-**EX1:** Fragment from OntoEmerge, an ontology about Emergency Plans (`see more <http://www.menthor.net/ontoemerge.html>`__):
+**EX1:** Fragment from OntoEmerge, an ontology about Emergency Plans (`see more <http://web.archive.org/web/20171008152105/http://www.menthor.net/ontoemerge.html>`__):
 
 .. container:: figure
 


### PR DESCRIPTION
Hi, reading the docs like this one: https://ontouml.readthedocs.io/en/latest/classes/nonsortals/category/index.html

Noticed that the links to menthor.net were all weird. Then reading the text I realized the domain had been apparently sold.

This PR replaces all links to menthor.net by links to the last time (October 2017) the old content was indexed by the WayBackMachine.

Thanks
Bruno