### PR TITLE
Included Phase as a possible subtype for Roles

### DIFF
--- a/classes/sortals/role/meta.yml
+++ b/classes/sortals/role/meta.yml
@@ -18,6 +18,7 @@ class_stereotype:
   - Mode
   - Quality
   subtypes:
+  - Phase  
   - Role
   forbidden_associations:
   - Structuration


### PR DESCRIPTION
This PR solves [Issue 20](https://github.com/OntoUML/OntoUML/issues/20), reported by @MichaelVrana.

The issue was created because Phase has Role as an allowed supertype, but Role doesn't have a Phase as an allowed subtype.

After discussions on the issue, a position was agreed by @claudenirmf, @MarekSuchanek, and @tgoprince (and also by me), defining that we are not going to make the specification overconstrained. This PR modifies the meta.yml file of Role allowing Phases as one of its subtypes. With this PR's approval [Issue 20](https://github.com/OntoUML/OntoUML/issues/20) can be closed.